### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ Iterable.prototype.identify = function(identify, fn){
  * @api public
  */
 
-Iterable.prototype.track = function(track, fn) {
+Iterable.prototype.track = function(track, fn){
   return this
     .post('/events/track')
     .type('json')
@@ -68,7 +68,7 @@ Iterable.prototype.track = function(track, fn) {
 };
 
 /**
- * Added/Removed Product.
+ * Product Added/Removed.
  *
  * Regular track call, unless properties.products is present
  *
@@ -77,15 +77,15 @@ Iterable.prototype.track = function(track, fn) {
  * @api public
  */
 
-Iterable.prototype.addedProduct =
-Iterable.prototype.removedProduct = function(track, fn) {
+Iterable.prototype.productAdded =
+Iterable.prototype.productRemoved = function(track, fn){
   var products = get(track.properties(), 'products');
   if (type(products) === 'array') {
     return this
       .post('/commerce/updateCart')
       .type('json')
       .set(headers(this.settings))
-      .send(mapper.addedProduct(track))
+      .send(mapper.productAdded(track))
       .end(this.handle(fn));
   } else {
     return this
@@ -98,7 +98,7 @@ Iterable.prototype.removedProduct = function(track, fn) {
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * https://api.iterable.com/api/docs#!/events/track_post_0
  *
@@ -107,15 +107,14 @@ Iterable.prototype.removedProduct = function(track, fn) {
  * @api public
  */
 
-Iterable.prototype.completedOrder = function(track, fn) {
+Iterable.prototype.orderCompleted = function(track, fn){
   return this
     .post('/commerce/trackPurchase')
     .type('json')
     .set(headers(this.settings))
-    .send(mapper.completedOrder(track))
+    .send(mapper.orderCompleted(track))
     .end(this.handle(fn));
 };
-
 
 function headers(settings) {
   return {

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -58,7 +58,7 @@ exports.identify = function(identify) {
  * @api private
  */
 
-exports.track = function(track) {
+exports.track = function(track){
   var properties = traverse(track.properties());
   var context = traverse(track.context());
   var contextFields = ['ip', 'userAgent']; // these are the only fields we're interested in
@@ -74,7 +74,7 @@ exports.track = function(track) {
 };
 
 /**
- * Map `Added Product and Removed Product`.
+ * Map `Product Added/Removed`.
  *
  * This is only invoked when a full products array is present
  *
@@ -83,8 +83,8 @@ exports.track = function(track) {
  * @api private
  */
 
-exports.addedProduct =
-exports.removedProduct = function(track) {
+exports.productAdded =
+exports.productRemoved = function(track){
   return {
     user: {
       email: track.email(),
@@ -95,14 +95,14 @@ exports.removedProduct = function(track) {
 };
 
 /**
- * Map `Completed Order`.
+ * Map `Order Completed`.
  *
  * @param {Track} track
  * @return {Object}
  * @api private
  */
 
-exports.completedOrder = function(track) {
+exports.orderCompleted = function(track){
   var specialFields = ['templateId', 'campaignId'];
   var props = track.properties();
   var result = {
@@ -112,7 +112,7 @@ exports.completedOrder = function(track) {
       userId: track.userId(),
       email: track.email()
     },
-    dataFields: foldl(function(acc, val, key) {
+    dataFields: foldl(function(acc, val, key){
       if (key !== 'total' && key !== 'products' && !includes(key, specialFields)) acc[key] = val;
       return acc;
     }, {}, props),
@@ -121,7 +121,6 @@ exports.completedOrder = function(track) {
   extend(result, pick(specialFields, props));
   return result;
 };
-
 
 /**
  * Turn a Segment products array into Iterable format
@@ -132,8 +131,8 @@ exports.completedOrder = function(track) {
  * @returns {Array}
  */
 
-function formatProducts(products) {
-  return products.map(function(item) {
+function formatProducts(products){
+  return products.map(function(item){
     var product = new Track({ properties: item });
     var payload = reject({
       id: product.id(),
@@ -147,7 +146,7 @@ function formatProducts(products) {
       url: product.proxy('properties.url')
     });
 
-    payload.dataFields = foldl(function(acc, val, key) {
+    payload.dataFields = foldl(function(acc, val, key){
       if (!payload.hasOwnProperty(key) && key !== 'category') acc[key] = val;
       return acc;
     }, {}, product.properties());

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "isodate-traverse": "^0.3.2",
     "obj-case": "^0.1.1",
     "reject": "0.0.1",
-    "segmentio-integration": "^3.0.5",
+    "segmentio-integration": "^4.0.0",
     "type-component": "0.0.1",
     "unix-time": "^1.0.1",
     "@ndhoule/pick": "^1.0.2",
@@ -31,7 +31,7 @@
     "mocha": "2.x",
     "ms": "0.x",
     "segmentio-facade": "2.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-integration-tester": "2.x",
     "should": "^4.3.0",
     "uid": "0.0.2",
     "unix-time": "^1.0.1"

--- a/test/fixtures/track-added-product.json
+++ b/test/fixtures/track-added-product.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "event": "Added Product",
+    "event": "Product Added",
     "userId": "some-uid",
     "timestamp": "2014",
     "properties": {

--- a/test/fixtures/track-purchase-campaign-id.json
+++ b/test/fixtures/track-purchase-campaign-id.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "userId": "some-uid",
     "timestamp": "2014",
     "properties": {

--- a/test/fixtures/track-purchase.json
+++ b/test/fixtures/track-purchase.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "userId": "some-uid",
     "timestamp": "2014",
     "properties": {

--- a/test/fixtures/track-purchase2.json
+++ b/test/fixtures/track-purchase2.json
@@ -7,7 +7,7 @@
         "version": "2.0.13"
       }
     },
-    "event": "Completed Order",
+    "event": "Order Completed",
     "integrations": {},
     "messageId": "7d050283-681c-4037-a67b-9960451bf130",
     "properties": {

--- a/test/fixtures/track-removed-product.json
+++ b/test/fixtures/track-removed-product.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "event": "Removed Product",
+    "event": "Product Removed",
     "userId": "some-uid",
     "timestamp": "2014",
     "properties": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -52,7 +52,7 @@ exports.transaction = function(options){
     userId: firstId,
     channel: 'server',
     timestamp: new Date,
-    event: 'Completed Order',
+    event: 'Order Completed',
     properties: {
       orderId: 't-39a224df',
       total: 99.99,

--- a/test/index.js
+++ b/test/index.js
@@ -83,11 +83,11 @@ describe('Iterable', function(){
         test.maps('track-userId-no-email');
       });
 
-      it('should map added product track', function(){
+      it('should map product added track', function(){
         test.maps('track-added-product');
       });
 
-      it('should map removed product track', function(){
+      it('should map product removed track', function(){
         test.maps('track-removed-product');
       });
 
@@ -133,7 +133,7 @@ describe('Iterable', function(){
         .error('cannot POST /api/events/track (401)', done);
     });
 
-    it('should map Added Product to updateCart if there is a cart provided', function(done){
+    it('should map Product Added to updateCart if there is a cart provided', function(done){
       var json = test.fixture('track-added-product');
 
       test
@@ -145,7 +145,7 @@ describe('Iterable', function(){
         .end(done);
     });
 
-    it('should not map Added Product to updateCart if there is no cart provided', function(done){
+    it('should not map Product Added to updateCart if there is no cart provided', function(done){
       var json = test.fixture('track-added-product');
       var input = json.input;
       input = objCase.del(input, 'properties.products');
@@ -158,7 +158,7 @@ describe('Iterable', function(){
         .end(done);
     });
 
-    it('should map Removed Product to updateCart if there is a cart provided', function(done){
+    it('should map Product Removed to updateCart if there is a cart provided', function(done){
       var json = test.fixture('track-removed-product');
 
       test
@@ -170,7 +170,7 @@ describe('Iterable', function(){
         .end(done);
     });
 
-    it('should not map Removed Product to updateCart if there is no cart provided', function(done){
+    it('should not map Product Removed to updateCart if there is no cart provided', function(done){
       var json = test.fixture('track-removed-product');
       var input = json.input;
       input = objCase.del(input, 'properties.products');
@@ -183,7 +183,7 @@ describe('Iterable', function(){
         .end(done);
     });
 
-    it('should map Completed Order to trackPurchase', function(done){
+    it('should map Order Completed to trackPurchase', function(done){
       var json = test.fixture('track-purchase');
 
       test
@@ -195,7 +195,7 @@ describe('Iterable', function(){
         .end(done);
     });
 
-    it('should map a more complex Completed Order to trackPurchase', function(done){
+    it('should map a more complex Order Completed to trackPurchase', function(done){
       var json = test.fixture('track-purchase2');
 
       test
@@ -207,7 +207,7 @@ describe('Iterable', function(){
         .end(done);
     });
 
-    it('should map a Completed Order with template and campaign ids to trackPurchase', function(done){
+    it('should map a Order Completed with template and campaign ids to trackPurchase', function(done){
       var json = test.fixture('track-purchase-campaign-id');
 
       test


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.