### PR TITLE
Don't add ip and userAgent in track calls

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -60,16 +60,12 @@ exports.identify = function(identify) {
 
 exports.track = function(track) {
   var properties = traverse(track.properties());
-  var context = traverse(track.context());
-  var contextFields = ['ip', 'userAgent']; // these are the only fields we're interested in
-  var interestingContext = pick(contextFields, context);
-  extend(interestingContext, properties);
   return {
     email: track.email(),
     userId: track.userId(),
     eventName: track.event(),
     createdAt: unixTime(track.timestamp()),
-    dataFields: interestingContext
+    dataFields: properties
   };
 };
 

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -35,9 +35,7 @@
       "prop": true,
       "email": "jd@example.com",
       "amount": 29.99,
-      "revenue": 19.99,
-      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36",
-      "ip": "67.188.108.15"
+      "revenue": 19.99
     }
   }
 }


### PR DESCRIPTION
We decided not to send these fields over with `track` anymore