### PR TITLE
support ecom spec v2

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -132,7 +132,7 @@ function formatProducts(products){
   return products.map(function(item){
     var product = new Track({ properties: item });
     var payload = reject({
-      id: product.id(),
+      id: product.productId() || product.id(),
       sku: product.sku(),
       name: product.name(),
       categories: [product.category()],
@@ -144,7 +144,7 @@ function formatProducts(products){
     });
 
     payload.dataFields = foldl(function(acc, val, key){
-      if (!payload.hasOwnProperty(key) && key !== 'category') acc[key] = val;
+      if (!payload.hasOwnProperty(key) && key !== 'category' && key !== 'product_id') acc[key] = val;
       return acc;
     }, {}, product.properties());
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "merge-util": "^0.1.0",
     "mocha": "2.x",
     "ms": "0.x",
-    "segmentio-facade": "2.x",
-    "segmentio-integration-tester": "2.x",
+    "segmentio-facade": "^3.x",
+    "segmentio-integration-tester": "^2.x",
     "should": "^4.3.0",
     "uid": "0.0.2",
     "unix-time": "^1.0.1"

--- a/test/fixtures/track-added-product.json
+++ b/test/fixtures/track-added-product.json
@@ -10,7 +10,7 @@
       "prop": true,
       "products": [
         {
-          "id": "foo-id",
+          "product_id": "foo-id",
           "sku": "foo-sku",
           "name": "foo-name",
           "price": 5.5,

--- a/test/fixtures/track-purchase-campaign-id.json
+++ b/test/fixtures/track-purchase-campaign-id.json
@@ -13,7 +13,7 @@
       "templateId": 777,
       "products": [
         {
-          "id": "foo-id",
+          "product_id": "foo-id",
           "sku": "foo-sku",
           "name": "foo-name",
           "price": 5.5,

--- a/test/fixtures/track-purchase.json
+++ b/test/fixtures/track-purchase.json
@@ -11,7 +11,7 @@
       "total": 11,
       "products": [
         {
-          "id": "foo-id",
+          "product_id": "foo-id",
           "sku": "foo-sku",
           "name": "foo-name",
           "price": 5.5,

--- a/test/fixtures/track-purchase2.json
+++ b/test/fixtures/track-purchase2.json
@@ -24,13 +24,13 @@
       "currency": "USD",
       "discount": 0,
       "email": "test@iterable.com",
-      "orderId": "R550311537",
+      "order_id": "R550311537",
       "products": [
         {
           "category": "pullover_hoodie",
           "color": "royal_blue",
           "gender": "male",
-          "id": "c94cfe418822",
+          "product_id": "c94cfe418822",
           "image_url": "https://loyalist.s3.amazonaws.com/orders/R550311537/line-items/131/images/french_terry_light_weight_pullover_hoodie/front/royal_blue/capybara.jpg",
           "name": "Lacrosse Force Standard Sweatshirt",
           "price": 39.1,
@@ -208,7 +208,7 @@
       "currency": "USD",
       "discount": 0,
       "email": "test@iterable.com",
-      "orderId": "R550311537",
+      "order_id": "R550311537",
       "revenue": "151.9",
       "shipping": "22.99",
       "shipping_address": {

--- a/test/fixtures/track-removed-product.json
+++ b/test/fixtures/track-removed-product.json
@@ -10,7 +10,7 @@
       "prop": true,
       "products": [
         {
-          "id": "foo-id",
+          "product_id": "foo-id",
           "sku": "foo-sku",
           "name": "foo-name",
           "price": 5.5,


### PR DESCRIPTION
@f2prateek 

Removing `product_id` from `payload.dataFields` since it would be duplicate data.
