### PR TITLE
Format Dates per Iterable's requirements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+1.4.3 / 2017-03-14
+==================
+
+  * Standardize Date formats to prevent uncaught exceptions and match Iterable's requirements.
 
 1.4.0 / 2017-01-31
 ==================

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -11,15 +11,7 @@ var reject = require('reject');
 var pick = require('@ndhoule/pick');
 var extend = require('@ndhoule/extend');
 var includes = require('@ndhoule/includes');
-
-/**
- * convert a date into the standard Iterable format "yyyy-MM-dd HH:mm:ss ZZ" (for example, 2015-04-15 10:46:45 +00:00), by fiddling with the ISO string (i.e., 2015-04-15T10:46:45.808Z)
- * @param date
- * @returns {string}
- */
-function dateToIterableDateStringFormat(date) {
-  return date.toISOString().replace('T', ' ').split('.')[0] + " +00:00";
-}
+var is = require('is');
 
 /**
  * Map `identify`.
@@ -31,23 +23,21 @@ function dateToIterableDateStringFormat(date) {
 
 exports.identify = function(identify) {
   // "phoneNumber" field in Iterable should be mapped from "phone" in Segment spec
-  var traits = traverse(identify.traits({ phone: 'phoneNumber' }));
-  var context = traverse(identify.context());
-  var created = identify.created();
-  if (created) traits.met = created.toISOString();
+  var traits = formatDates(extend(identify.traits({
+    phone: 'phoneNumber',
+    timestamp: 'profileUpdatedAt'
+  }), { met: identify.created() }));
+
   del(traits, 'id');
-  var ts = identify.timestamp();
-  if (ts) {
-    traits['profileUpdatedAt'] = dateToIterableDateStringFormat(ts);
-  }
-  var contextFields = ['app', 'device', 'ip', 'locale', 'location', 'page', 'timeZone', 'userAgent']; // these are the only fields we're interested in
-  context['timeZone'] = context['timezone'];
-  var interestingContext = pick(contextFields, context);
-  extend(interestingContext, traits);
+
+  var context = extend(identify.context(), { timeZone: identify.timezone() });
+  var whitelist = ['app', 'device', 'ip', 'locale', 'location', 'page', 'timeZone', 'userAgent'];
+  context = formatDates(pick(whitelist, context));
+
   return {
     email: identify.email(),
     userId: identify.userId(),
-    dataFields: interestingContext
+    dataFields: reject(extend(context, traits))
   };
 };
 
@@ -60,7 +50,8 @@ exports.identify = function(identify) {
  */
 
 exports.track = function(track){
-  var properties = traverse(track.properties());
+  var properties = formatDates(track.properties());
+
   return {
     email: track.email(),
     userId: track.userId(),
@@ -150,4 +141,34 @@ function formatProducts(products){
 
     return payload;
   });
+}
+
+/**
+ * convert a date into the standard Iterable format "yyyy-MM-dd HH:mm:ss ZZ" (for example, 2015-04-15 10:46:45 +00:00), by fiddling with the ISO string (i.e., 2015-04-15T10:46:45.808Z)
+ * @param date
+ * @returns {string}
+ **/
+
+function dateToIterableDateStringFormat(date) {
+  return date.toISOString().replace('T', ' ').split('.')[0] + " +00:00";
+}
+
+/**
+* Format Dates.
+*
+* https://support.iterable.com/hc/en-us/articles/208183076-Data-Field-Types-in-Iterable
+*
+* @param {Object} obj Traits or properties
+* @return {Object}
+**/
+
+function formatDates(obj) {
+  return foldl(function(acc, val, key) {
+    if (is.date(val)) {
+      acc[key] = dateToIterableDateStringFormat(val);
+    } else {
+      acc[key] = val;
+    }
+    return acc;
+  }, {}, traverse(obj));
 }

--- a/package.json
+++ b/package.json
@@ -13,16 +13,17 @@
     "test": "make test"
   },
   "dependencies": {
+    "@ndhoule/extend": "^1.0.1",
     "@ndhoule/foldl": "^1.0.3",
+    "@ndhoule/includes": "^1.0.0",
+    "@ndhoule/pick": "^1.0.2",
+    "is": "^3.2.0",
     "isodate-traverse": "^0.3.2",
     "obj-case": "^0.1.1",
     "reject": "0.0.1",
     "segmentio-integration": "^5.1.0",
     "type-component": "0.0.1",
-    "unix-time": "^1.0.1",
-    "@ndhoule/pick": "^1.0.2",
-    "@ndhoule/extend": "^1.0.1",
-    "@ndhoule/includes": "^1.0.0"
+    "unix-time": "^1.0.1"
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.4.0",
@@ -39,6 +40,7 @@
     "segmentio-integration-tester": "^2.x",
     "should": "^4.3.0",
     "uid": "0.0.2",
-    "unix-time": "^1.0.1"
+    "unix-time": "^1.0.1",
+    "moment": "^2.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-iterable",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Iterable server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -15,8 +15,8 @@
     "userId": "user-id",
     "dataFields": {
       "email": "jd@example.com",
-      "created": "2014-01-01T00:00:00.000Z",
-      "met": "2014-01-01T00:00:00.000Z",
+      "created": "2014-01-01 00:00:00 +00:00",
+      "met": "2014-01-01 00:00:00 +00:00",
       "trait": true,
       "profileUpdatedAt": "2014-01-01 00:00:00 +00:00",
       "phoneNumber": "12121234567"

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -22,6 +22,7 @@
     "properties": {
       "amount": 29.99,
       "revenue": 19.99,
+      "dateExample":"2015-12-10T04:08:31.905Z",
       "email": "jd@example.com",
       "prop": true
     }
@@ -35,7 +36,8 @@
       "prop": true,
       "email": "jd@example.com",
       "amount": 29.99,
-      "revenue": 19.99
+      "revenue": 19.99,
+      "dateExample":"2015-12-10 04:08:31 +00:00"
     }
   }
 }


### PR DESCRIPTION
Hey folks!

This commit addresses this [JIRA ticket](https://segment.atlassian.net/browse/EPD-1089).

The Iterable [data field type spec](https://support.iterable.com/hc/en-us/articles/208183076-Data-Field-Types-in-Iterable) and [API schema](https://api.iterable.com/api-docs/events) confirm that the `timestamp` field is correct. The code updates below clean up some of the data transformation, and check to see if any of the `dataField` fields are ISO date strings. ISO date strings are converted to the format needed by Iterable.

Note: Iterable sets the data type when it sees a field for the first time. This will affect all new fields added, as Iterable will now recognize them as a Date-time data type. Existing fields will remain as a String value. Formatting of that String will change per the  [JIRA ticket (https://segment.atlassian.net/browse/EPD-1089).

Example of the correct format:
```javascript
{
"email": "justin@iterable.com",
"dataFields": {
   "lastCartUpdateDate":"2015-02-03 01:20:55 +00:00"
  }
}
```

@thehydroimpulse 
@hankim813 
@sperand-io 
@ndhoule 
